### PR TITLE
Add --enable-module-recovery to ./configure command

### DIFF
--- a/Formula/secp256k1.rb
+++ b/Formula/secp256k1.rb
@@ -14,7 +14,7 @@ class Secp256k1 < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", "prefix=#{prefix}", "--disable-silent-rules"
+    system "./configure", "prefix=#{prefix}", "--disable-silent-rules", "--enable-module-recovery"
     system "make"
     system "./tests"
     system "make", "install"


### PR DESCRIPTION
Many C/C++ (and other) libraries depend on secp256k1_recovery.h. This ssue was first raised when attempting `opam install secp256k1`, an Ocaml of the C version.