### PR TITLE
secp256k1: --with-enable-recovery-module option and fix build on macOS 10.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: ruby
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11.1
+      rvm: system
+      env: HOMEBREW_DEVELOPER=1 HOMEBREW_NO_AUTO_UPDATE=1
+
+before_install:
+  - sudo chown -R "$USER" "$(brew --repo)"
+  - travis_retry brew update
+  - HOMEBREW_TAP_DIR="$(brew --repo "$TRAVIS_REPO_SLUG")"
+  - mkdir -p "$HOMEBREW_TAP_DIR"
+  - rm -rf "$HOMEBREW_TAP_DIR"
+  - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
+  - ulimit -n 1024
+
+script:
+  - brew test-bot --ci-testing
+
+notifications:
+  email:
+    on_success: never
+    on_failure: never

--- a/Formula/bearssl.rb
+++ b/Formula/bearssl.rb
@@ -1,0 +1,36 @@
+class Bearssl < Formula
+  desc "Implementation of the SSL/TLS protocol written in C"
+  homepage "https://bearssl.org/index.html"
+  url "https://bearssl.org/bearssl-0.6.tar.gz"
+  sha256 "6705bba1714961b41a728dfc5debbe348d2966c117649392f8c8139efc83ff14"
+  head "https://www.bearssl.org/git/BearSSL", :using => :git
+
+  depends_on "doxygen" => :build
+  depends_on "graphviz" => :build
+
+  def install
+    system "make"
+
+    system "doxygen"
+    doc.install Dir["apidoc/html/*"]
+
+    cd "build" do
+      # Run the crypto testsuite.
+      system "./testcrypto", "all"
+
+      bin.install "brssl"
+      lib.install "libbearssl.a"
+      lib.install "libbearssl.so" => "libbearssl.dylib"
+    end
+    (include/"bearssl").install Dir["inc/*.h"]
+  end
+
+  test do
+    # Generate a dummy test cert. Is immediately deleted at test completion.
+    system "openssl", "req", "-x509", "-newkey", "rsa:4096", "-keyout", "key.pem",
+           "-out", "cert.pem", "-days", "1", "-nodes", "-subj", "/CN=test"
+
+    output = shell_output("#{bin}/brssl verify cert.pem 2>&1", 1)
+    assert_match "Key type: RSA (4096 bits)", output
+  end
+end

--- a/Formula/bfgminer.rb
+++ b/Formula/bfgminer.rb
@@ -1,0 +1,48 @@
+class Bfgminer < Formula
+  desc "Modular ASIC/FPGA miner written in C"
+  homepage "https://github.com/luke-jr/bfgminer"
+  url "http://bfgminer.org/files/5.5.0/bfgminer-5.5.0.txz"
+  sha256 "ac254da9a40db375cb25cacdd2f84f95ffd7f442e31d2b9a7f357a48d32cc681"
+
+  option "with-cpumining", "Build with cpumining support"
+
+  depends_on "pkg-config" => :build
+  depends_on "yasm" => :build
+  depends_on "curl" => :recommended
+  depends_on "hidapi"
+  depends_on "jansson"
+  depends_on "libmicrohttpd"
+  depends_on "libevent"
+  depends_on "libusb"
+
+  resource "uthash" do
+    url "https://github.com/troydhanson/uthash/archive/v2.0.2.tar.gz"
+    sha256 "34a31d51dd7a839819cecd6f46049b4ffe031d7f3147d9a042f5504fdb1348d1"
+  end
+
+  def install
+    resource("uthash").stage do
+      (buildpath/"uthash/include").install Dir["src/*.h"]
+    end
+    ENV.append_to_cflags "-I#{buildpath}/uthash/include"
+
+    args = %W[
+      --prefix=#{prefix}
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --enable-keccak
+      --enable-opencl
+      --enable-scrypt
+      --without-system-libbase58
+    ]
+    args << "--enable-cpumining" if build.with? "cpumining"
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system bin/"bfgminer", "--version"
+  end
+end

--- a/Formula/bopenssh.rb
+++ b/Formula/bopenssh.rb
@@ -1,0 +1,73 @@
+class Bopenssh < Formula
+  desc "OpenBSD freely-licensed SSH connectivity tools"
+  homepage "https://www.openssh.com/"
+  url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz"
+  mirror "https://mirror.vdms.io/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz"
+  version "8.1p1"
+  sha256 "02f5dbef3835d0753556f973cd57b4c19b6b1f6cd24c03445e23ac77ca1b93ff"
+
+  depends_on "pkg-config" => :build
+  depends_on "libressl"
+  depends_on "ldns" => :optional
+
+  # Both these patches are applied by Apple.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/1860b0a74/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff"
+    sha256 "d886b98f99fd27e3157b02b5b57f3fb49f43fd33806195970d4567f12be66e71"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2/openssh/patch-sshd.c-apple-sandbox-named-external.diff"
+    sha256 "3505c58bf1e584c8af92d916fe5f3f1899a6b15cc64a00ddece1dc0874b2f78f"
+  end
+
+  resource "com.openssh.sshd.sb" do
+    url "https://opensource.apple.com/source/OpenSSH/OpenSSH-220.50.1/com.openssh.sshd.sb"
+    sha256 "a273f86360ea5da3910cfa4c118be931d10904267605cdd4b2055ced3a829774"
+  end
+
+  def install
+    ENV.append "CPPFLAGS", "-D__APPLE_SANDBOX_NAMED_EXTERNAL__"
+
+    # Ensure sandbox profile prefix is correct.
+    # We introduce this issue with patching, it's not an upstream bug.
+    inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
+
+    args = %W[
+      --with-libedit
+      --with-pam
+      --with-kerberos5
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}/ssh
+      --with-ssl-dir=#{Formula["libressl"].opt_prefix}
+    ]
+
+    args << "--with-ldns" if build.with? "ldns"
+
+    system "./configure", *args
+    system "make"
+    ENV.deparallelize
+    system "make", "install"
+
+    # This was removed by upstream with very little announcement and has
+    # potential to break scripts, so recreate it for now.
+    # Debian have done the same thing.
+    bin.install_symlink bin/"ssh" => "slogin"
+
+    buildpath.install resource("com.openssh.sshd.sb")
+    (etc/"ssh").install "com.openssh.sshd.sb" => "org.openssh.sshd.sb"
+  end
+
+  test do
+    assert_match "OpenSSH_", shell_output("#{bin}/ssh -V 2>&1")
+
+    begin
+      pid = fork { exec sbin/"sshd", "-D", "-p", "8022" }
+      sleep 2
+      assert_match "sshd", shell_output("lsof -i :8022")
+    ensure
+      Process.kill(9, pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/Formula/boringssl.rb
+++ b/Formula/boringssl.rb
@@ -1,0 +1,61 @@
+class GoRequirement < Requirement
+  fatal true
+
+  satisfy(:build_env => false) { which("go") }
+
+  def message; <<~EOS
+    boringssl requires golang to compile:
+      brew install go
+  EOS
+  end
+end
+
+class Boringssl < Formula
+  desc "Google fork of OpenSSL"
+  homepage "https://boringssl.googlesource.com/boringssl"
+  url "https://boringssl.googlesource.com/boringssl.git",
+      :revision => "bf5021a6b8a4859d04966998e84fcbff16bffd78"
+  version "0.0.0.117" # Fake version so we can update the formula regularly.
+  head "https://boringssl.googlesource.com/boringssl.git"
+
+  keg_only <<~EOS
+    Apple provides an old OpenSSL, which conflicts with this.
+    It also conflicts with Homebrew's shipped OpenSSL and LibreSSL
+  EOS
+
+  depends_on "cmake" => :build
+  depends_on GoRequirement => :build
+  depends_on "ninja" => :build
+
+  def install
+    doc.mkpath
+    cd "util" do
+      system "go", "build", "doc.go"
+      system "./doc", "--config", "doc.config", "--out", doc
+    end
+
+    mkdir "build" do
+      system "cmake", "-GNinja", "..", "-DBUILD_SHARED_LIBS=1", *std_cmake_args
+      system "ninja"
+      system "go", "run", buildpath/"util/all_tests.go"
+
+      # Workaround https://github.com/Homebrew/brew/issues/4792.
+      libcrypto = MachO::MachOFile.new(buildpath/"build/crypto/libcrypto.dylib").dylib_id
+      MachO::Tools.change_install_name("tool/bssl", libcrypto, "#{opt_lib}/libcrypto.dylib")
+      libssl = MachO::MachOFile.new(buildpath/"build/ssl/libssl.dylib").dylib_id
+      MachO::Tools.change_install_name("tool/bssl", libssl, "#{opt_lib}/libssl.dylib")
+      MachO::Tools.change_install_name("ssl/libssl.dylib", libcrypto, "#{opt_lib}/libcrypto.dylib")
+
+      # There's no real Makefile as such. We have to handle this manually.
+      bin.install "tool/bssl"
+      lib.install "crypto/libcrypto.dylib", "ssl/libssl.dylib"
+    end
+    include.install Dir["include/*"]
+  end
+
+  test do
+    (testpath/"testfile.txt").write "This is a test file"
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    assert_match expected_checksum, shell_output("#{bin}/bssl sha256sum testfile.txt")
+  end
+end

--- a/Formula/curl-max.rb
+++ b/Formula/curl-max.rb
@@ -1,0 +1,210 @@
+class CurlMax < Formula
+  desc "Feature-maximised version of cURL, using OpenSSL 1.1"
+  homepage "https://curl.haxx.se/"
+  url "https://curl.haxx.se/download/curl-7.67.0.tar.bz2"
+  sha256 "dd5f6956821a548bf4b44f067a530ce9445cc8094fd3e7e3fc7854815858586c"
+
+  bottle do
+    root_url "https://dl.bintray.com/domt4/crypto-bottles"
+    sha256 "54118f8d419dfabfa5388f9450ddee05d40e0b131ed22b1f760a723b0e6c45e8" => :catalina
+  end
+
+  keg_only :provided_by_macos
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cunit" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "c-ares"
+  depends_on "jansson"
+  depends_on "jemalloc"
+  depends_on "libev"
+  depends_on "libidn2"
+  depends_on "libmetalink"
+  depends_on "libpsl"
+  depends_on "openssl@1.1"
+
+  # Needed for nghttp2
+  resource "libevent" do
+    url "https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz"
+    sha256 "a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d"
+  end
+
+  resource "nghttp2" do
+    url "https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.xz"
+    sha256 "a2d216450abd2beaf4e200c168957968e89d602ca4119338b9d7ab059fd4ce8b"
+
+    unless OS.mac?
+      patch do
+        # Fix: shrpx_api_downstream_connection.cc:57:3: error: array must be initialized with a brace-enclosed initializer
+        url "https://gist.githubusercontent.com/iMichka/5dda45fbad3e70f52a6b4e7dfd382969/raw/19797e17926922bdd1ef21a47e162d8be8e2ca65/nghttp2?full_index=1"
+        sha256 "0759d448d4b419911c12fa7d5cbf1df2d6d41835c9077bf3accf9eac58f24f12"
+      end
+    end
+  end
+
+  resource "libssh2" do
+    url "https://libssh2.org/download/libssh2-1.9.0.tar.gz"
+    sha256 "d5fb8bd563305fd1074dda90bd053fb2d29fc4bce048d182f96eaa466dfadafd"
+  end
+
+  resource "libxml2" do
+    url "http://xmlsoft.org/sources/libxml2-2.9.10.tar.gz"
+    mirror "https://ftp.osuosl.org/pub/blfs/conglomeration/libxml2/libxml2-2.9.10.tar.gz"
+    sha256 "aafee193ffb8fe0c82d4afef6ef91972cbaf5feea100edc2f262750611b4be1f"
+  end
+
+  def install
+    vendor = libexec/"vendor"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@1.1"].opt_lib/"pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", vendor/"lib/pkgconfig"
+    ENV.prepend_path "PATH", vendor/"bin"
+
+    resource("libxml2").stage do
+      system "./configure", "--disable-dependency-tracking",
+                            "--prefix=#{vendor}",
+                            "--without-python",
+                            "--without-lzma"
+      system "make", "install"
+    end
+
+    resource("libevent").stage do
+      system "./configure", "--disable-dependency-tracking",
+                            "--disable-debug-mode",
+                            "--prefix=#{vendor}"
+      system "make"
+      system "make", "install"
+    end
+
+    resource("nghttp2").stage do
+      args = %W[
+        --prefix=#{vendor}
+        --disable-silent-rules
+        --enable-app
+        --with-boost=#{Formula["boost"].opt_prefix}
+        --enable-asio-lib
+        --disable-python-bindings
+      ]
+      # requires thread-local storage features only available in 10.11+
+      args << "--disable-threads" if MacOS.version < :el_capitan
+
+      system "./configure", *args
+      system "make"
+      system "make", "check"
+      system "make", "install"
+    end
+
+    resource("libssh2").stage do
+      system "./configure", "--prefix=#{vendor}",
+                            "--disable-debug",
+                            "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--disable-examples-build",
+                            "--with-openssl",
+                            "--with-libz",
+                            "--with-libssl-prefix=#{Formula["openssl@1.1"].opt_prefix}"
+      system "make", "install"
+    end
+
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --prefix=#{prefix}
+      --with-libidn2
+      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ca-bundle=#{etc}/openssl@1.1/cert.pem
+      --with-ca-path=#{etc}/openssl@1.1/certs
+      --enable-ares=#{Formula["c-ares"].opt_prefix}
+      --with-libssh2
+      --without-librtmp
+      --with-gssapi
+      --with-libmetalink
+    ]
+    args << "--disable-ldap" unless OS.mac?
+
+    system "./configure", *args
+    system "make", "install"
+    libexec.install "lib/mk-ca-bundle.pl"
+
+    # curl-config --libs outputs all libs, even private ones.
+    # Is a known issue upstream but can cause problems when
+    # third-parties try to link against curl. Can be fixed
+    # with an inreplace until upstream find a happy solution.
+    inreplace bin/"curl-config",
+              "${CURLLIBDIR}-lcurl -lcares",
+              "${CURLLIBDIR} -L#{vendor}/lib -lcurl -lcares"
+  end
+
+  test do
+    # Test vendored libraries.
+    (testpath/"test.c").write <<~EOS
+      #include <event2/event.h>
+
+      int main()
+      {
+        struct event_base *base;
+        base = event_base_new();
+        event_base_free(base);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{libexec}/vendor/lib",
+                   "-I#{libexec}/vendor/include", "-levent", "-o", "test"
+    system "./test"
+
+    (testpath/"test2.c").write <<~EOS
+      #include <libssh2.h>
+
+      int main(void)
+      {
+      libssh2_exit();
+      return 0;
+      }
+    EOS
+
+    system ENV.cc, "test2.c", "-L#{libexec}/vendor/lib",
+                   "-I#{libexec}/vendor/include", "-lssh2", "-o", "test2"
+    system "./test2"
+
+    (testpath/"test3.c").write <<~EOS
+      #include <libxml/tree.h>
+
+      int main()
+      {
+        xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");
+        xmlNodePtr root_node = xmlNewNode(NULL, BAD_CAST "root");
+        xmlDocSetRootElement(doc, root_node);
+        xmlFreeDoc(doc);
+        return 0;
+      }
+    EOS
+    args = shell_output("#{libexec}/vendor/bin/xml2-config --cflags --libs").split
+    args += %w[test3.c -o test3]
+    system ENV.cc, *args
+    system "./test3"
+
+    # Test vendored executables.
+    system libexec/"vendor/bin/nghttp", "-nv", "https://nghttp2.org"
+
+    # Test IDN support.
+    ENV.delete("LC_CTYPE")
+    ENV["LANG"] = "en_US.UTF-8"
+    system bin/"curl", "-L", "www.räksmörgås.se", "-o", "index.html"
+    assert_predicate testpath/"index.html", :exist?,
+                     "Failed to download IDN example site!"
+    assert_match "www.xn--rksmrgs-5wao1o.se", File.read("index.html")
+
+    # Fetch the curl tarball and see that the checksum matches.
+    # This requires a network connection, but so does Homebrew in general.
+    filename = (testpath/"test.tar.gz")
+    system bin/"curl", "-L", stable.url, "-o", filename
+    filename.verify_checksum stable.checksum
+
+    system libexec/"mk-ca-bundle.pl", "test.pem"
+    assert_predicate testpath/"test.pem", :exist?, "Failed to generate PEM!"
+    assert_predicate testpath/"certdata.txt", :exist?
+  end
+end

--- a/Formula/deluge.rb
+++ b/Formula/deluge.rb
@@ -1,0 +1,195 @@
+class Deluge < Formula
+  include Language::Python::Virtualenv
+
+  desc "Popular open-source bittorrent client"
+  homepage "http://deluge-torrent.org/"
+  url "https://files.pythonhosted.org/packages/58/9c/a612e85487c055d88da0f975a81cabf5d04dfb87a2aace2ae5946115113f/deluge-2.0.3.tar.gz"
+  sha256 "bd26950f417de2a5b26827d989935a30e770f880c22cb59ca69f781cdc9a14c9"
+  revision 1
+
+  head "https://git.deluge-torrent.org/deluge", :branch => "develop"
+
+  depends_on "intltool" => :build
+  depends_on "boost-python3"
+  depends_on "freetype"
+  depends_on "geoip"
+  depends_on "gettext"
+  depends_on "gtk-mac-integration"
+  depends_on "librsvg"
+  depends_on "libtorrent-rasterbar"
+  depends_on "openssl@1.1"
+  depends_on "py3cairo"
+  depends_on "pygobject3"
+  depends_on "python"
+
+  resource "asn1crypto" do
+    url "https://files.pythonhosted.org/packages/fc/f1/8db7daa71f414ddabfa056c4ef792e1461ff655c2ae2928a2b675bfed6b4/asn1crypto-0.24.0.tar.gz"
+    sha256 "9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/cc/d9/931a24cc5394f19383fbbe3e1147a0291276afa43a0dc3ed0d6cd9fda813/attrs-19.1.0.tar.gz"
+    sha256 "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+  end
+
+  resource "Automat" do
+    url "https://files.pythonhosted.org/packages/4a/4f/64db3ffda8828cb0541fe949354615f39d02f596b4c33fb74863756fc565/Automat-0.7.0.tar.gz"
+    sha256 "cbd78b83fa2d81fe2a4d23d258e1661dd7493c9a50ee2f1a5b2cac61c1793b0e"
+  end
+
+  resource "cffi" do
+    url "https://files.pythonhosted.org/packages/93/1a/ab8c62b5838722f29f3daffcc8d4bd61844aa9b5f437341cc890ceee483b/cffi-1.12.3.tar.gz"
+    sha256 "041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774"
+  end
+
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+  end
+
+  resource "constantly" do
+    url "https://files.pythonhosted.org/packages/95/f1/207a0a478c4bb34b1b49d5915e2db574cadc415c9ac3a7ef17e29b2e8951/constantly-15.1.0.tar.gz"
+    sha256 "586372eb92059873e29eba4f9dec8381541b4d3834660707faf8ba59146dfc35"
+  end
+
+  resource "cryptography" do
+    url "https://files.pythonhosted.org/packages/c2/95/f43d02315f4ec074219c6e3124a87eba1d2d12196c2767fadfdc07a83884/cryptography-2.7.tar.gz"
+    sha256 "e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6"
+  end
+
+  resource "hyperlink" do
+    url "https://files.pythonhosted.org/packages/e0/46/1451027b513a75edf676d25a47f601ca00b06a6a7a109e5644d921e7462d/hyperlink-19.0.0.tar.gz"
+    sha256 "4288e34705da077fada1111a24a0aa08bb1e76699c9ce49876af722441845654"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/ad/13/eb56951b6f7950cadb579ca166e448ba77f9d24efc03edd7e55fa57d04b7/idna-2.8.tar.gz"
+    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+  end
+
+  resource "incremental" do
+    url "https://files.pythonhosted.org/packages/8f/26/02c4016aa95f45479eea37c90c34f8fab6775732ae62587a874b619ca097/incremental-17.5.0.tar.gz"
+    sha256 "7b751696aaf36eebfab537e458929e194460051ccad279c72b755a167eebd4b3"
+  end
+
+  resource "Mako" do
+    url "https://files.pythonhosted.org/packages/b0/3c/8dcd6883d009f7cae0f3157fb53e9afb05a0d3d33b3db1268ec2e6f4a56b/Mako-1.1.0.tar.gz"
+    sha256 "a36919599a9b7dc5d86a7a8988f23a9a3a3d083070023bab23d64f7f1d1e0a4b"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
+    sha256 "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+  end
+
+  resource "Pillow" do
+    url "https://files.pythonhosted.org/packages/51/fe/18125dc680720e4c3086dd3f5f95d80057c41ab98326877fc7d3ff6d0ee5/Pillow-6.1.0.tar.gz"
+    sha256 "0804f77cb1e9b6dbd37601cee11283bba39a8d44b9ddb053400c58e0c0d7d9de"
+  end
+
+  resource "pyasn1" do
+    url "https://files.pythonhosted.org/packages/ca/f8/2a60a2c88a97558bdd289b6dc9eb75b00bd90ff34155d681ba6dbbcb46b2/pyasn1-0.4.7.tar.gz"
+    sha256 "a9495356ca1d66ed197a0f72b41eb1823cf7ea8b5bd07191673e8147aecf8604"
+  end
+
+  resource "pyasn1-modules" do
+    url "https://files.pythonhosted.org/packages/f1/a9/a1ef72a0e43feff643cf0130a08123dea76205e7a0dda37e3efb5f054a31/pyasn1-modules-0.2.6.tar.gz"
+    sha256 "43c17a83c155229839cc5c6b868e8d0c6041dba149789b6d6e28801c64821722"
+  end
+
+  resource "pycparser" do
+    url "https://files.pythonhosted.org/packages/68/9e/49196946aee219aead1290e00d1e7fdeab8567783e83e1b9ab5585e6206a/pycparser-2.19.tar.gz"
+    sha256 "a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+  end
+
+  resource "PyHamcrest" do
+    url "https://files.pythonhosted.org/packages/a4/89/a469aad9256aedfbb47a29ec2b2eeb855d9f24a7a4c2ff28bd8d1042ef02/PyHamcrest-1.9.0.tar.gz"
+    sha256 "8ffaa0a53da57e89de14ced7185ac746227a8894dbd5a3c718bf05ddbd1d56cd"
+  end
+
+  resource "pyOpenSSL" do
+    url "https://files.pythonhosted.org/packages/40/d0/8efd61531f338a89b4efa48fcf1972d870d2b67a7aea9dcf70783c8464dc/pyOpenSSL-19.0.0.tar.gz"
+    sha256 "aeca66338f6de19d1aa46ed634c3b9ae519a64b458f8468aec688e7e3c20f200"
+  end
+
+  resource "pyxdg" do
+    url "https://files.pythonhosted.org/packages/47/6e/311d5f22e2b76381719b5d0c6e9dc39cd33999adae67db71d7279a6d70f4/pyxdg-0.26.tar.gz"
+    sha256 "fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06"
+  end
+
+  resource "rencode" do
+    url "https://files.pythonhosted.org/packages/3a/fb/3c03dbe4438dd596e1378b5299990b81041739658a76e0f4a301eded67f4/rencode-1.0.6.tar.gz"
+    sha256 "2586435c4ea7d45f74e26765ad33d75309de7cf47c4d762e8efabd39905c0718"
+  end
+
+  resource "service_identity" do
+    url "https://files.pythonhosted.org/packages/9a/3d/9eb0563e066ea0540cf580695593ab079376e920016d4d1b3ff2fd8abf4b/service_identity-18.1.0.tar.gz"
+    sha256 "0858a54aabc5b459d1aafa8a518ed2081a285087f349fe3e55197989232e2e2d"
+  end
+
+  resource "setproctitle" do
+    url "https://files.pythonhosted.org/packages/5a/0d/dc0d2234aacba6cf1a729964383e3452c52096dc695581248b548786f2b3/setproctitle-1.1.10.tar.gz"
+    sha256 "6283b7a58477dd8478fbb9e76defb37968ee4ba47b05ec1c053cb39638bd7398"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  resource "Twisted" do
+    url "https://files.pythonhosted.org/packages/61/31/3855dcacd1d3b2e60c0b4ccc8e727b8cd497bd7087d327d81a9f0cbb580c/Twisted-19.7.0.tar.bz2"
+    sha256 "d5db93026568f60cacdc0615fcd21d46f694a6bfad0ef3ff53cde2b4bb85a39d"
+  end
+
+  resource "zope.interface" do
+    url "https://files.pythonhosted.org/packages/4e/d0/c9d16bd5b38de44a20c6dc5d5ed80a49626fafcb3db9f9efdc2a19026db6/zope.interface-4.6.0.tar.gz"
+    sha256 "1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5"
+  end
+
+  def install
+    venv = virtualenv_create(libexec, "python3")
+
+    resource("Pillow").stage do
+      inreplace "setup.py" do |s|
+        sdkprefix = MacOS.sdk_path_if_needed ? MacOS.sdk_path : ""
+        s.gsub! "openjpeg.h", "probably_not_a_header_called_this_eh.h"
+        s.gsub! "ZLIB_ROOT = None", "ZLIB_ROOT = ('#{sdkprefix}/usr/lib', '#{sdkprefix}/usr/include')"
+        s.gsub! "JPEG_ROOT = None", "JPEG_ROOT = ('#{Formula["jpeg"].opt_prefix}/lib', '#{Formula["jpeg"].opt_prefix}/include')"
+        s.gsub! "FREETYPE_ROOT = None", "FREETYPE_ROOT = ('#{Formula["freetype"].opt_prefix}/lib', '#{Formula["freetype"].opt_prefix}/include')"
+      end
+
+      # avoid triggering "helpful" distutils code that doesn't recognize Xcode 7 .tbd stubs
+      ENV.delete "SDKROOT"
+      ENV.append "CFLAGS", "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers" unless MacOS::CLT.installed?
+      venv.pip_install Pathname.pwd
+    end
+
+    res = resources.map(&:name).to_set - ["Pillow"]
+
+    res.each do |r|
+      venv.pip_install resource(r)
+    end
+
+    venv.pip_install_and_link buildpath
+
+    # dlopen(libintl.dylib, 6): image not found
+    inreplace libexec/"lib/python3.7/site-packages/deluge/i18n/util.py",
+              "libintl.dylib",
+              Formula["gettext"].opt_lib/"libintl.dylib"
+  end
+
+  test do
+    pid = fork do
+      exec "#{bin}/deluge-web --port=8081"
+    end
+    sleep 2
+
+    begin
+      assert_match "Deluge WebUI #{version}", shell_output("curl localhost:8081 2>&1")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/Formula/electrum.rb
+++ b/Formula/electrum.rb
@@ -1,0 +1,205 @@
+class Electrum < Formula
+  include Language::Python::Virtualenv
+
+  desc "Bitcoin thin client"
+  homepage "https://electrum.org"
+  url "https://download.electrum.org/3.3.8/Electrum-3.3.8.tar.gz"
+  sha256 "e2adf191847609d5bd850320f647db6347952b170364a463276db27a836400bc"
+  revision 1
+
+  bottle do
+    root_url "https://dl.bintray.com/domt4/crypto-bottles"
+    cellar :any_skip_relocation
+    sha256 "df0a4fcc55e0d91ba3eb0deba3e381bb9a3cea185daf5ff35a5b23ca1391026d" => :mojave
+  end
+
+  depends_on "protobuf"
+  depends_on "pyqt"
+  depends_on "python"
+
+  resource "Cython" do
+    url "https://files.pythonhosted.org/packages/5b/5b/6cba7123a089c4174f944dd05ea7984c8d908aba8746a99f2340dde8662f/Cython-0.29.12.tar.gz"
+    sha256 "20da832a5e9a8e93d1e1eb64650258956723940968eb585506531719b55b804f"
+  end
+
+  resource "QDarkStyle" do
+    url "https://files.pythonhosted.org/packages/a4/ec/c6ae1509370f07ef2ac725cfed6add23b94670a5903a834a463440ca295a/QDarkStyle-2.6.8.tar.gz"
+    sha256 "037a54bf0aa5153f8055b65b8b36ac0d0f7648f2fd906c011a4da22eb0f582a2"
+  end
+
+  resource "aiohttp" do
+    url "https://files.pythonhosted.org/packages/0f/58/c8b83f999da3b13e66249ea32f325be923791c0c10aee6cf16002a3effc1/aiohttp-3.5.4.tar.gz"
+    sha256 "9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf"
+  end
+
+  resource "aiohttp-socks" do
+    url "https://files.pythonhosted.org/packages/c2/78/3cf7de8bcb047e1969d6b49d7ea50ef4d8254b3f1512721e425ad94ec1c0/aiohttp_socks-0.2.2.tar.gz"
+    sha256 "eebd8939a7c3c1e3e7e1b2552c60039b4c65ef6b8b2351efcbdd98290538e310"
+  end
+
+  resource "aiorpcX" do
+    url "https://files.pythonhosted.org/packages/4e/c5/9aacc2f50e06919c3f1d34137d1acea980f2449df7c4f9149c37b306e492/aiorpcX-0.18.3.tar.gz"
+    sha256 "b7a7ced5df95c79c74f7834e7cc58bb7747dbad9eb37bf7580da507e182ca44c"
+  end
+
+  resource "async_timeout" do
+    url "https://files.pythonhosted.org/packages/a1/78/aae1545aba6e87e23ecab8d212b58bb70e72164b67eb090b81bb17ad38e3/async-timeout-3.0.1.tar.gz"
+    sha256 "0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/cc/d9/931a24cc5394f19383fbbe3e1147a0291276afa43a0dc3ed0d6cd9fda813/attrs-19.1.0.tar.gz"
+    sha256 "f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+  end
+
+  resource "btchip-python" do
+    url "https://files.pythonhosted.org/packages/66/26/52b88daa03da39cc8d7178f945af0dcbba46d642ced6ea56e305762568ae/btchip-python-0.1.28.tar.gz"
+    sha256 "da09d0d7a6180d428833795ea9a233c3b317ddfcccea8cc6f0eba59435e5dd83"
+  end
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/c5/67/5d0548226bcc34468e23a0333978f0e23d28d0b3f0c71a151aef9c3f7680/certifi-2019.6.16.tar.gz"
+    sha256 "945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+  end
+
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz"
+    sha256 "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+  end
+
+  resource "ckcc-protocol" do
+    url "https://files.pythonhosted.org/packages/35/9a/a49ee1591dc7d532a6905988934cbd94e44e917f2d5660b2d3d88239ec3f/ckcc-protocol-0.7.7.tar.gz"
+    sha256 "3c3815342354ccbf63ba7ecfa5f0c27e56a308d7157f1b02835868977659c979"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/f8/5c/f60e9d8a1e77005f664b76ff8aeaee5bc05d0a91798afd7f53fc998dbc47/Click-7.0.tar.gz"
+    sha256 "5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+  end
+
+  resource "construct" do
+    url "https://files.pythonhosted.org/packages/19/c0/f054941fa33d14378de66d2c0477d31f7ad97aa2e298a5771a7b20bc2039/construct-2.9.45.tar.gz"
+    sha256 "2271a0efd0798679dea825ff47e22a4c550456a5db0ba8baa82f7eae0af0118c"
+  end
+
+  resource "dnspython" do
+    url "https://files.pythonhosted.org/packages/ec/c5/14bcd63cb6d06092a004793399ec395405edf97c2301dfdc146dfbd5beed/dnspython-1.16.0.zip"
+    sha256 "36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01"
+  end
+
+  resource "ecdsa" do
+    url "https://files.pythonhosted.org/packages/51/76/139bf6e9b7b6684d5891212cdbd9e0739f2bfc03f380a1a6ffa700f392ac/ecdsa-0.13.2.tar.gz"
+    sha256 "5c034ffa23413ac923541ceb3ac14ec15a0d2530690413bff58c12b80e56d884"
+  end
+
+  resource "hidapi" do
+    url "https://files.pythonhosted.org/packages/c1/86/89df0e8890f96eeb5fb68d4ccb14cb38e2c2d2cfd7601ba972206acd9015/hidapi-0.7.99.post21.tar.gz"
+    sha256 "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/ad/13/eb56951b6f7950cadb579ca166e448ba77f9d24efc03edd7e55fa57d04b7/idna-2.8.tar.gz"
+    sha256 "c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"
+  end
+
+  resource "jsonrpclib-pelix" do
+    url "https://files.pythonhosted.org/packages/5c/4e/67c832052d6d85731732193b5d58ff9c2c3ec91087324ad5c2d814fc56c9/jsonrpclib-pelix-0.4.0.tar.gz"
+    sha256 "19c558e169a51480b39548783067ca55046b62b2409ab4559931255e12f635de"
+  end
+
+  resource "keepkey" do
+    url "https://files.pythonhosted.org/packages/61/f7/5487352c4a724fa864c442938b4b44244beaeec34e1d351916611441345f/keepkey-6.1.0.tar.gz"
+    sha256 "2e1623409307c86f709054ad191bc7707c4feeacae2e497bd933f2f0054c6eb0"
+  end
+
+  resource "libusb1" do
+    url "https://files.pythonhosted.org/packages/80/bb/4ee9d760dd29499d877ee384f1d2bc6bb9923defd4c69843aef5e729972d/libusb1-1.7.1.tar.gz"
+    sha256 "adf64a4f3f5c94643a1286f8153bcf4bc787c348b38934aacd7fe17fbeebc571"
+  end
+
+  resource "mnemonic" do
+    url "https://files.pythonhosted.org/packages/a4/5a/663362ccceb76035ad50fbc20203b6a4674be1fe434886b7407e79519c5e/mnemonic-0.18.tar.gz"
+    sha256 "02a7306a792370f4a0c106c2cf1ce5a0c84b9dbd7e71c6792fdb9ad88a727f1d"
+  end
+
+  resource "multidict" do
+    url "https://files.pythonhosted.org/packages/7f/8f/b3c8c5b062309e854ce5b726fc101195fbaa881d306ffa5c2ba19efa3af2/multidict-4.5.2.tar.gz"
+    sha256 "024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f"
+  end
+
+  resource "pbkdf2" do
+    url "https://files.pythonhosted.org/packages/02/c0/6a2376ae81beb82eda645a091684c0b0becb86b972def7849ea9066e3d5e/pbkdf2-1.3.tar.gz"
+    sha256 "ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"
+  end
+
+  resource "protobuf" do
+    url "https://files.pythonhosted.org/packages/cd/02/0425c38def9047d77166abdc9bb66dcff2882095c57b952511c85720f03c/protobuf-3.9.0.tar.gz"
+    sha256 "b3452bbda12b1cbe2187d416779de07b2ab4c497d83a050e43c344778763721d"
+  end
+
+  resource "pyaes" do
+    url "https://files.pythonhosted.org/packages/44/66/2c17bae31c906613795711fc78045c285048168919ace2220daa372c7d72/pyaes-1.6.1.tar.gz"
+    sha256 "02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"
+  end
+
+  resource "pyblake2" do
+    url "https://files.pythonhosted.org/packages/a6/ea/559658f48713567276cabe1344a9ef918adcb34a9da417dbf0a2f7477d8e/pyblake2-1.1.2.tar.gz"
+    sha256 "5ccc7eb02edb82fafb8adbb90746af71460fbc29aa0f822526fc976dff83e93f"
+  end
+
+  resource "qrcode" do
+    url "https://files.pythonhosted.org/packages/19/d5/6c7d4e103d94364d067636417a77a6024219c58cd6e9f428ece9b5061ef9/qrcode-6.1.tar.gz"
+    sha256 "505253854f607f2abf4d16092c61d4e9d511a3b4392e60bff957a68592b04369"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz"
+    sha256 "11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"
+  end
+
+  resource "safet" do
+    url "https://files.pythonhosted.org/packages/94/dd/31e2d333e61d80baa0d24dcb12f890d17e803f7d6f73145a4fa4c41058b4/safet-0.1.4.tar.gz"
+    sha256 "b152874acdc89ff0c8b2d680bfbf020b3e53527c2ad3404489dd61a548aa56a1"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/dd/bf/4138e7bfb757de47d1f4b6994648ec67a51efe58fa907c1e11e350cddfca/six-1.12.0.tar.gz"
+    sha256 "d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+  end
+
+  resource "trezor" do
+    url "https://files.pythonhosted.org/packages/88/9e/9b84a35c3709cda7b35a211dc9617f38740eb2d3a46a20a1087efb795302/trezor-0.11.3.tar.gz"
+    sha256 "c79a500e90d003073c8060d319dceb042caaba9472f13990c77ed37d04a82108"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/59/b6/21774b993eec6e797fbc49e53830df823b69a3cb62f94d36dfb497a0b65a/typing_extensions-3.7.4.tar.gz"
+    sha256 "2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/4c/13/2386233f7ee40aa8444b47f7463338f3cbdf00c316627558784e3f542f07/urllib3-1.25.3.tar.gz"
+    sha256 "dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+  end
+
+  resource "websocket_client" do
+    url "https://files.pythonhosted.org/packages/c5/01/8c9c7de6c46f88e70b5a3276c791a2be82ae83d8e0d0cc030525ee2866fd/websocket_client-0.56.0.tar.gz"
+    sha256 "1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b297fd3a"
+  end
+
+  resource "yarl" do
+    url "https://files.pythonhosted.org/packages/fb/84/6d82f6be218c50b547aa29d0315e430cf8a23c52064c92d0a8377d7b7357/yarl-1.3.0.tar.gz"
+    sha256 "024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9"
+  end
+
+  def install
+    # https://stackoverflow.com/a/44466013
+    ENV.delete("PYTHONPATH")
+
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system bin/"electrum", "--help"
+  end
+end

--- a/Formula/git-max.rb
+++ b/Formula/git-max.rb
@@ -1,0 +1,179 @@
+class GoRequirement < Requirement
+  fatal true
+
+  satisfy(:build_env => false) { which("go") }
+
+  def message; <<~EOS
+    git-max requires golang to compile:
+      brew install go
+  EOS
+  end
+end
+
+class GitMax < Formula
+  desc "Distributed revision control system"
+  homepage "https://git-scm.com"
+  url "https://www.kernel.org/pub/software/scm/git/git-2.24.0.tar.xz"
+  sha256 "9f71d61973626d8b28c4cdf8e2484b4bf13870ed643fed982d68b2cfd754371b"
+  head "https://github.com/git/git.git", :shallow => false
+
+  bottle do
+    root_url "https://dl.bintray.com/domt4/crypto-bottles"
+    sha256 "f4f5c72eda56cebf24f92579639cdfc7dab90ccd709f6868af2ad68d1c730aff" => :catalina
+  end
+
+  depends_on GoRequirement => :build
+  depends_on "domt4/crypto/curl-max"
+  depends_on "openssl@1.1"
+  depends_on "pcre2"
+  # So bindings can be found & used by Homebrew's Perl.
+  depends_on "perl" => :recommended
+  depends_on "gettext" => :optional
+  depends_on "subversion" => :optional
+
+  conflicts_with "git",
+    :because => "git-max is a feature-heavy version of the git formula"
+
+  resource "html" do
+    url "https://www.kernel.org/pub/software/scm/git/git-htmldocs-2.24.0.tar.xz"
+    sha256 "05b6ed0719d5e29d5c60dd7d0a5469f4a0514008a64f6084ac26335d1b37f73b"
+  end
+
+  resource "man" do
+    url "https://www.kernel.org/pub/software/scm/git/git-manpages-2.24.0.tar.xz"
+    sha256 "b0c872c16f22942c1cb6c90ec07f395a931f7c2f9fb920d2ec926674265c04a6"
+  end
+
+  def install
+    # If these things are installed, tell Git build system not to use them
+    ENV["NO_FINK"] = "1"
+    ENV["NO_DARWIN_PORTS"] = "1"
+    # This is the default now when not using CommonCrypto but set it regardless
+    # in case we ever move back to CommonCrypto here in future.
+    ENV["DC_SHA1"] = "1"
+    ENV["V"] = "1" # build verbosely
+    ENV["NO_INSTALL_HARDLINKS"] = "1" # https://github.com/Homebrew/brew/issues/4921
+    ENV["SOURCE_DATE_EPOCH"] = "1"
+    ENV["NO_R_TO_GCC_LINKER"] = "1" # pass arguments to LD correctly
+    ENV["PYTHON_PATH"] = which("python")
+    ENV["PERL_PATH"] = which("perl")
+
+    perl_version = Utils.popen_read("perl --version")[/v(\d+\.\d+)(?:\.\d+)?/, 1]
+    # If building with a non-system Perl search everywhere declared in @INC.
+    perl_inc = Utils.popen_read("perl -e 'print join\":\",@INC'").sub(":.", "")
+
+    if build.with? "subversion"
+      ENV["PERLLIB_EXTRA"] = %W[
+        #{Formula["subversion"].opt_lib}/perl5/site_perl
+      ].join(":")
+    elsif build.with? "perl"
+      ENV["PERLLIB_EXTRA"] = perl_inc
+    elsif MacOS.version >= :mavericks
+      ENV["PERLLIB_EXTRA"] = %W[
+        #{MacOS.active_developer_dir}
+        /Library/Developer/CommandLineTools
+        /Applications/Xcode.app/Contents/Developer
+      ].uniq.map do |p|
+        "#{p}/Library/Perl/#{perl_version}/darwin-thread-multi-2level"
+      end.join(":")
+    end
+
+    unless quiet_system ENV["PERL_PATH"], "-e", "use ExtUtils::MakeMaker"
+      ENV["NO_PERL_MAKEMAKER"] = "1"
+    end
+
+    ENV["NO_GETTEXT"] = "1" if build.without? "gettext"
+    ENV["USE_LIBPCRE2"] = "1"
+    ENV["LIBPCREDIR"] = Formula["pcre2"].opt_prefix
+
+    args = %W[
+      prefix=#{prefix}
+      sysconfdir=#{etc}
+      CC=#{ENV.cc}
+      CFLAGS=#{ENV.cflags}
+      LDFLAGS=#{ENV.ldflags}
+      NO_APPLE_COMMON_CRYPTO=1
+      OPENSSLDIR=#{Formula["openssl@1.1"].opt_prefix}
+    ]
+
+    system "make", "install", *args
+
+    git_core = libexec/"git-core"
+
+    # Install the macOS keychain credential helper
+    cd "contrib/credential/osxkeychain" do
+      system "make", "CC=#{ENV.cc}",
+                     "CFLAGS=#{ENV.cflags}",
+                     "LDFLAGS=#{ENV.ldflags}"
+      git_core.install "git-credential-osxkeychain"
+      system "make", "clean"
+    end
+
+    # Generate diff-highlight perl script executable
+    cd "contrib/diff-highlight" do
+      system "make"
+    end
+
+    # Install the netrc credential helper
+    cd "contrib/credential/netrc" do
+      system "make", "test"
+      git_core.install "git-credential-netrc"
+    end
+
+    # Install git-subtree
+    cd "contrib/subtree" do
+      system "make", "CC=#{ENV.cc}",
+                     "CFLAGS=#{ENV.cflags}",
+                     "LDFLAGS=#{ENV.ldflags}"
+      git_core.install "git-subtree"
+    end
+
+    cd "contrib/persistent-https" do
+      system "make"
+      git_core.install "git-remote-persistent-http",
+                       "git-remote-persistent-https",
+                       "git-remote-persistent-https--proxy"
+    end
+
+    # install the completion script first because it is inside "contrib"
+    bash_completion.install "contrib/completion/git-completion.bash"
+    bash_completion.install "contrib/completion/git-prompt.sh"
+
+    zsh_completion.install "contrib/completion/git-completion.zsh" => "_git"
+    cp "#{bash_completion}/git-completion.bash", zsh_completion
+
+    elisp.install Dir["contrib/emacs/*.el"]
+    (share/"git-core").install "contrib"
+
+    # We could build the manpages ourselves, but the build process depends
+    # on many other packages, and is somewhat crazy, this way is easier.
+    man.install resource("man")
+    (share/"doc/git-doc").install resource("html")
+
+    # Make html docs world-readable
+    chmod 0644, Dir["#{share}/doc/git-doc/**/*.{html,txt}"]
+    chmod 0755, Dir["#{share}/doc/git-doc/{RelNotes,howto,technical}"]
+
+    # This is only created when building against system Perl, but it isn't
+    # purged by Homebrew's post-install cleaner because that doesn't check
+    # "Library" directories. It is however pointless to keep around as it
+    # only contains the perllocal.pod installation file.
+    rm_rf prefix/"Library/Perl"
+
+    # Set the macOS keychain credential helper by default
+    # (as Apple's CLT's git also does this).
+    (buildpath/"gitconfig").write <<~EOS
+      [credential]
+      \thelper = osxkeychain
+    EOS
+    etc.install "gitconfig"
+  end
+
+  test do
+    system bin/"git", "init"
+    %w[haunted house].each { |f| touch testpath/f }
+    system bin/"git", "add", "haunted", "house"
+    system bin/"git", "commit", "-a", "-m", "Initial Commit"
+    assert_equal "haunted\nhouse", shell_output("#{bin}/git ls-files").strip
+  end
+end

--- a/Formula/gnu-wget.rb
+++ b/Formula/gnu-wget.rb
@@ -1,0 +1,62 @@
+class GnuWget < Formula
+  desc "Internet file retriever built against LibreSSL"
+  homepage "https://www.gnu.org/software/wget/"
+  url "https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz"
+  sha256 "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
+
+  head do
+    url "https://git.savannah.gnu.org/git/wget.git"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "xz" => :build
+    depends_on "gettext"
+  end
+
+  option "with-default-names", "Do not prepend 'l' to the binary"
+
+  depends_on "pkg-config" => :build
+  depends_on "pod2man" => :build if MacOS.version <= :snow_leopard
+  depends_on "libressl"
+  depends_on "libidn2" => :recommended
+  depends_on "gpgme" => :optional
+  depends_on "libmetalink" => :optional
+  depends_on "pcre" => :optional
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --with-ssl=openssl
+      --with-libssl-prefix=#{Formula["libressl"].opt_prefix}
+      --disable-debug
+    ]
+
+    args << "--program-prefix=l" if build.without? "default-names"
+    args << "--disable-pcre" if build.without? "pcre"
+    args << "--with-metalink" if build.with? "libmetalink"
+    args << "--with-gpgme-prefix=#{Formula["gpgme"].opt_prefix}" if build.with? "gpgme"
+
+    system "./bootstrap" if build.head?
+    system "./configure", *args
+    system "make", "install"
+
+    if build.without? "default-names"
+      mv info/"wget.info", info/"lwget.info"
+      mv man1/"wget.1", man1/"lwget.1"
+      rm_rf share/"locale" # Not worth renaming every single file here.
+    end
+  end
+
+  def caveats
+    return if build.with? "default-names"
+    <<~EOS
+      The binary is prepended with a 'l' so this can be used
+      alongside Homebrew's `wget` without conflict.
+    EOS
+  end
+
+  test do
+    system bin/"lwget", "-O", "/dev/null", "https://duckduckgo.com"
+  end
+end

--- a/Formula/parcimonie-sh.rb
+++ b/Formula/parcimonie-sh.rb
@@ -1,0 +1,63 @@
+class ParcimonieSh < Formula
+  desc "Refresh your GnuPG keyring discreetly"
+  homepage "https://github.com/EtiennePerot/parcimonie.sh"
+  url "https://github.com/EtiennePerot/parcimonie.sh.git",
+      :revision => "2a9bb4dd95a25032a68820556c00b2d2f7069912"
+  version "0.0.0.5" # Fake version to allow easier updates.
+  version_scheme 1
+
+  head "https://github.com/EtiennePerot/parcimonie.sh.git"
+
+  depends_on "gnupg"
+  depends_on "torsocks"
+  depends_on "tor"
+
+  def install
+    inreplace "parcimonie.sh" do |s|
+      s.gsub! "${TORSOCKS_BINARY:-torsocks}", "${TORSOCKS_BINARY:-#{Formula["torsocks"].opt_bin}/torsocks}"
+      s.gsub! "${GNUPG_BINARY:-}", "${GNUPG_BINARY:-#{Formula["gnupg"].opt_bin}/gnupg}"
+    end
+
+    bin.install "parcimonie.sh" => "parcimonie"
+  end
+
+  def post_install
+    (var/"parcimonie").mkpath
+  end
+
+  def caveats; <<~EOS
+    Tor must be running for parcimonie to work.
+
+    Note if using GnuPG 2.1.x there are some potential issues:
+      https://github.com/EtiennePerot/parcimonie.sh/issues/15
+  EOS
+  end
+
+  plist_options :manual => "parcimonie"
+
+  def plist; <<~EOS
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <true/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>/bin/sh</string>
+            <string>-c</string>
+            <string>#{opt_bin}/parcimonie</string>
+        </array>
+        <key>StandardErrorPath</key>
+        <string>#{var}/parcimonie/keyupdate.err</string>
+        <key>StandardOutPath</key>
+        <string>#{var}/parcimonie/keyupdate.out</string>
+      </dict>
+    </plist>
+    EOS
+  end
+end

--- a/Formula/ricochet.rb
+++ b/Formula/ricochet.rb
@@ -1,0 +1,57 @@
+class Ricochet < Formula
+  desc "Anonymous peer-to-peer instant messaging"
+  homepage "https://ricochet.im"
+  url "https://ricochet.im/releases/1.1.4/ricochet-1.1.4-src.tar.bz2"
+  sha256 "f5f32caa3480def1de5c93010c6bf5f5789ddcba34bf09fc0feab67696d0c374"
+  revision 23
+  head "https://github.com/ricochet-im/ricochet.git"
+
+  depends_on "pkg-config" => :build
+  depends_on "qt"
+  depends_on "openssl@1.1"
+  depends_on "protobuf"
+  depends_on "libevent" # For Tor
+
+  resource "tor" do
+    url "https://www.torproject.org/dist/tor-0.4.1.6.tar.gz"
+    mirror "https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.1.6.tar.gz"
+    sha256 "2a88524ce426079fb9b828bc1b789f2c8ade3ed53c130851102debc3518bed71"
+  end
+
+  def install
+    (var/"ricochet").mkpath
+    openssl = Formula["openssl@1.1"].opt_prefix
+
+    system "qmake", "-config", "release", "OPENSSLDIR=#{openssl}",
+                    "INCLUDEPATH+=#{openssl}/include", "LIBS+=-L#{openssl}/lib"
+    system "make"
+    libexec.install "Ricochet.app"
+
+    resource("tor").stage do
+      args = %W[
+        --disable-dependency-tracking
+        --disable-silent-rules
+        --prefix=#{libexec}/Ricochet.app/Contents/Resources/tor
+        --sysconfdir=#{libexec}/Ricochet.app/Contents/Resources/tor/unused
+        --with-openssl-dir=#{openssl}
+      ]
+
+      system "./configure", *args
+      system "make", "install"
+      (libexec/"Ricochet.app/Contents/MacOS").install_symlink Dir[libexec/"Ricochet.app/Contents/Resources/tor/bin/*"]
+    end
+  end
+
+  def caveats; <<~EOS
+    Configuration files will be automatically generated upon first run.
+
+    You may wish to backup #{opt_libexec}/config.ricochet to somewhere that
+    will persist across updates such as #{var}/ricochet.
+  EOS
+  end
+
+  test do
+    output = shell_output("#{libexec}/Ricochet.app/Contents/MacOS/tor --version")
+    assert_match resource("tor").version.to_s, output
+  end
+end

--- a/Formula/secp256k1.rb
+++ b/Formula/secp256k1.rb
@@ -1,0 +1,36 @@
+class Secp256k1 < Formula
+  desc "Bitcoin experimental curves library"
+  homepage "https://github.com/bitcoin-core/secp256k1"
+  url "https://github.com/bitcoin-core/secp256k1.git",
+      :revision => "ef83281c3a264e8346cb3c9d0db233b86a881663"
+  version "0.0.0.54" # Fake version number to make updates easier.
+  head "https://github.com/bitcoin-core/secp256k1.git"
+
+  option "with-enable-module-recovery", "Enable ECDSA pubkey recovery module"
+
+  depends_on "automake" => :build
+  depends_on "autoconf" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "gmp"
+
+  def install
+    args = %W[
+      prefix=#{prefix}
+      --disable-silent-rules
+    ]
+    # Workaround for https://github.com/bitcoin-core/secp256k1/issues/674
+    if MacOS.version == :catalina
+      args << "CC=clang"
+      args << "CFLAGS=-mmacosx-version-min=10.15"
+      args << "LDFLAGS=-Wl,-bind_at_load"
+    end
+    args << "--enable-module-recovery" if build.with? "enable-module-recovery"
+
+    system "./autogen.sh"
+    system "./configure", *args
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2014- Dominyk Tiller and all other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# homebrew-crypto
+
+[![Build Status](https://travis-ci.org/DomT4/homebrew-crypto.svg?branch=master)](https://travis-ci.org/DomT4/homebrew-crypto)
+
+Various often experimental or unstable cryptographic-related formulae.
+
+## How do I install these formulae?
+
+Just `brew tap domt4/crypto` and then `brew install <formula>`.
+
+You can also install via URL:
+
+```
+brew install https://raw.githubusercontent.com/DomT4/homebrew-crypto/master/Formula/<formula>.rb
+```
+Troubleshooting:
+--------------------------------
+
+If you encounter any errors, feel free to file an issue. A `brew gist-logs <formula>` is often handy. Thanks!


### PR DESCRIPTION
This PR adds `--with-enable-module-recovery` option superseding https://github.com/DomT4/homebrew-crypto/pull/95 and fixes the package on macOS 10.15 Catalina (see https://github.com/bitcoin-core/secp256k1/issues/674 -- `make` works fine, but the tests segfault).